### PR TITLE
Make the signing scheme configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,31 +297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
  "bech32",
- "bitcoin_hashes 0.11.0",
+ "bitcoin_hashes",
  "secp256k1",
 ]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin_hashes"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
-dependencies = [
- "bitcoin-internals",
- "hex-conservative",
-]
 
 [[package]]
 name = "bitflags"
@@ -859,12 +843,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-conservative"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
 
 [[package]]
 name = "http"
@@ -1507,7 +1485,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
 dependencies = [
- "bitcoin_hashes 0.11.0",
+ "bitcoin_hashes",
  "rand",
  "secp256k1-sys",
 ]
@@ -1632,7 +1610,6 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-trait",
- "bitcoin_hashes 0.13.0",
  "chrono",
  "clap",
  "clokwerk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "sha-1",
  "smallvec",
  "zstd",
@@ -274,15 +274,6 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
-name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
@@ -295,32 +286,42 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bech32"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bitcoin"
-version = "0.27.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a41df6ad9642c5c15ae312dd3d074de38fd3eb7cc87ad4ce10f90292a83fe4d"
+checksum = "0694ea59225b0c5f3cb405ff3f670e4828358ed26aec49dc352f730f0cb1a8a3"
 dependencies = [
  "bech32",
- "bitcoin_hashes 0.10.0",
- "secp256k1 0.20.3",
+ "bitcoin_hashes 0.11.0",
+ "secp256k1",
 ]
 
 [[package]]
-name = "bitcoin_hashes"
-version = "0.9.7"
+name = "bitcoin-internals"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -462,15 +463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,7 +519,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -591,25 +583,26 @@ dependencies = [
 
 [[package]]
 name = "dlc"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1642ecf16a65702e5d8c41c74d371a099f4de5df0bb48258a1ed1a5e016daa8a"
+checksum = "19c812e884d551a686e5c8d0273e6e2232a6a1665bc5ea07d9ca9f84d3b02fb5"
 dependencies = [
  "bitcoin",
- "secp256k1-sys 0.4.1",
- "secp256k1-zkp 0.5.0",
+ "miniscript",
+ "secp256k1-sys",
+ "secp256k1-zkp",
 ]
 
 [[package]]
 name = "dlc-messages"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e59cf3cc712797390aabe00911bdeddd4aa1060790f234b647958cadbb53fb6"
+checksum = "179aeea57514dad634802716f6759febd88f78f111979747ddcb7d9afc9c9048"
 dependencies = [
  "bitcoin",
  "dlc",
  "lightning",
- "secp256k1-zkp 0.5.0",
+ "secp256k1-zkp",
 ]
 
 [[package]]
@@ -701,12 +694,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -874,6 +861,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-conservative"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed443af458ccb6d81c1e7e661545f94d3176752fb1df2f543b902a1e0f51e2"
+
+[[package]]
 name = "http"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,7 +960,7 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "hashbrown",
 ]
 
@@ -1030,12 +1023,11 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "lightning"
-version = "0.0.106"
+version = "0.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580647f97f8e6d138ad724027c8ca9b890b1001b05374c270bbee4c10309b641"
+checksum = "087add70f81d2fdc6d4409bc0cef69e11ad366ef1d0068550159bd22b3ac8664"
 dependencies = [
  "bitcoin",
- "secp256k1 0.20.3",
 ]
 
 [[package]]
@@ -1062,7 +1054,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "scopeguard",
 ]
 
@@ -1093,7 +1085,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -1101,6 +1093,15 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniscript"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f536c4b9b0868b37f4fb276758831fa93401f1fadc03447607f06ef4c72ee1"
+dependencies = [
+ "bitcoin",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1147,7 +1148,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -1157,7 +1158,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -1223,7 +1224,7 @@ version = "0.9.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1370,42 +1371,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.8",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1415,23 +1387,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1440,77 +1397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1617,84 +1503,43 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secp256k1"
-version = "0.20.3"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
+checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
 dependencies = [
- "bitcoin_hashes 0.9.7",
- "rand 0.6.5",
- "secp256k1-sys 0.4.1",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
-dependencies = [
- "bitcoin_hashes 0.10.0",
- "rand 0.6.5",
- "secp256k1-sys 0.5.2",
+ "bitcoin_hashes 0.11.0",
+ "rand",
+ "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "secp256k1-zkp"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e2709b09561dfb584b366bd418ee5549a858873baa707ed83d3eb986e34abf"
+checksum = "fd403e9f0569b4131ab3fc9fa24a17775331b39382efd2cde851fdca655e3520"
 dependencies = [
- "rand 0.6.5",
- "secp256k1 0.20.3",
- "secp256k1-zkp-sys 0.5.0",
-]
-
-[[package]]
-name = "secp256k1-zkp"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c724fda6aae465ed9a39320202bc6164e0adb3cdf9bc16d5af4be7eebaba75e5"
-dependencies = [
- "rand 0.6.5",
- "secp256k1 0.22.1",
- "secp256k1-zkp-sys 0.6.0",
+ "rand",
+ "secp256k1",
+ "secp256k1-zkp-sys",
 ]
 
 [[package]]
 name = "secp256k1-zkp-sys"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c48e70d04fdd871498db6ac3b35eeae0a339ab1cd06af483fe8a6835d36def"
+checksum = "64e7a2beac087c1da2d21018a3b7f043fe2f138654ad9c1518d409061a4a0034"
 dependencies = [
  "cc",
- "secp256k1-sys 0.4.1",
-]
-
-[[package]]
-name = "secp256k1-zkp-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f880412a627e79d3ce17355150ea1e0e76570efb7f0f70df51504cbe2582e3"
-dependencies = [
- "cc",
- "secp256k1-sys 0.5.2",
+ "secp256k1-sys",
 ]
 
 [[package]]
@@ -1787,6 +1632,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-trait",
+ "bitcoin_hashes 0.13.0",
  "chrono",
  "clap",
  "clokwerk",
@@ -1802,9 +1648,9 @@ dependencies = [
  "parking_lot 0.12.0",
  "queues",
  "reqwest",
- "secp256k1-sys 0.5.2",
- "secp256k1-zkp 0.5.0",
- "secp256k1-zkp 0.6.0",
+ "secp256k1",
+ "secp256k1-sys",
+ "secp256k1-zkp",
  "serde",
  "serde_json",
  "sled",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ sled = "0.34"
 thiserror = "1.0.31"
 time = { version = "0.3.9", features = ["formatting", "serde-human-readable"] }
 tokio = { version = "1.18.2", features = ["full"] }
-bitcoin_hashes = "0.13.0"
 
 [dev-dependencies]
 dlc = "~0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,26 +13,27 @@ chrono = "0.4"
 clap = { version = "3.2.5", features = ["derive"] }
 clokwerk = "0.4.0-rc1"
 displaydoc = "0.2"
-dlc-messages = "0.2.0"
+dlc-messages = "~0.4.0"
+lightning = "0.0.113" # used by dlc-messages
 env_logger = "0.9.0"
 futures = "0.3.21"
 hex = "0.4"
 humantime = "2.1.0"
-lightning = "0.0.106"
 log = "0.4.17"
 parking_lot = "0.12.0"
 queues = "1.1.0"
 reqwest = { version = "0.11.10", features = ["json"] }
-secp256k1-sys = "0.5.2"
-secp256k1-zkp = { version = "0.6.0", features = ["bitcoin_hashes", "rand-std"] }
-secp256k1-zkp-5 = { package = "secp256k1-zkp", version = "0.5" }
+secp256k1-zkp = { version = "0.7.0", features = ["bitcoin_hashes", "rand-std"] }
+secp256k1 = "0.24.3" # used by secp256k1-zkp
+secp256k1-sys = "0.6.0"# used by secp256k1
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 sled = "0.34"
 thiserror = "1.0.31"
 time = { version = "0.3.9", features = ["formatting", "serde-human-readable"] }
 tokio = { version = "1.18.2", features = ["full"] }
+bitcoin_hashes = "0.13.0"
 
 [dev-dependencies]
-dlc = "0.2.0"
+dlc = "~0.4.0"
 tokio-test = "0.4.2"

--- a/config/oracle.json
+++ b/config/oracle.json
@@ -2,5 +2,5 @@
     "attestation_time": "08:00",
     "frequency": "1d",
     "announcement_offset": "7d8h",
-    "signing_version": "basic"
+    "signing_version": "dlc_v0"
 }

--- a/config/oracle.json
+++ b/config/oracle.json
@@ -1,5 +1,6 @@
 {
     "attestation_time": "08:00",
     "frequency": "1d",
-    "announcement_offset": "7d8h"
+    "announcement_offset": "7d8h",
+    "signing_version": "basic"
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -29,7 +29,6 @@ impl From<&EventDescriptor> for SerializableEventDescriptor {
                 precision: e.precision,
                 num_digits: e.nb_digits,
             },
-            // a dummy descriptor for all kind of enum events
             EnumEvent(_) => SerializableEventDescriptor {
                 base: 0,
                 is_signed: false,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,5 @@
-use crate::oracle::EventDescriptor;
+use dlc_messages::oracle_msgs::EventDescriptor::{DigitDecompositionEvent, EnumEvent};
+use dlc_messages::oracle_msgs::{DigitDecompositionEventDescriptor, EventDescriptor};
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display, Formatter};
 use time::{serde::format_description, Duration, Time};
@@ -10,9 +11,52 @@ pub enum AssetPair {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+pub struct SerializableEventDescriptor {
+    pub base: u16,
+    pub is_signed: bool,
+    pub unit: String,
+    pub precision: i32,
+    pub num_digits: u16,
+}
+
+impl From<&EventDescriptor> for SerializableEventDescriptor {
+    fn from(ed: &EventDescriptor) -> SerializableEventDescriptor {
+        match ed {
+            DigitDecompositionEvent(e) => SerializableEventDescriptor {
+                base: e.base,
+                is_signed: e.is_signed,
+                unit: e.unit.clone(),
+                precision: e.precision,
+                num_digits: e.nb_digits,
+            },
+            // a dummy descriptor for all kind of enum events
+            EnumEvent(_) => SerializableEventDescriptor {
+                base: 0,
+                is_signed: false,
+                unit: "".to_string(),
+                precision: 0,
+                num_digits: 0,
+            },
+        }
+    }
+}
+
+impl From<SerializableEventDescriptor> for EventDescriptor {
+    fn from(val: SerializableEventDescriptor) -> Self {
+        DigitDecompositionEvent(DigitDecompositionEventDescriptor {
+            base: val.base,
+            is_signed: val.is_signed,
+            unit: val.unit.clone(),
+            precision: val.precision,
+            nb_digits: val.num_digits,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
 pub struct AssetPairInfo {
     pub asset_pair: AssetPair,
-    pub event_descriptor: EventDescriptor,
+    pub event_descriptor: SerializableEventDescriptor,
     pub exclude_price_feeds: Vec<String>,
 }
 
@@ -76,6 +120,14 @@ mod standard_duration {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub enum SigningVersion {
+    #[serde(rename = "basic")]
+    Basic,
+    #[serde(rename = "dlc_v0")]
+    DLCv0,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct OracleConfig {
     #[serde(with = "standard_time")]
     pub attestation_time: Time,
@@ -83,4 +135,5 @@ pub struct OracleConfig {
     pub frequency: Duration,
     #[serde(with = "standard_duration")]
     pub announcement_offset: Duration,
+    pub signing_version: SigningVersion,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,4 @@ pub use common::*;
 
 pub mod oracle;
 
-pub use oracle::oracle_scheduler::{
-    build_announcement, build_attestation,
-    messaging::{Announcement, Attestation, EventDescriptor, OracleEvent},
-};
+pub use oracle::oracle_scheduler::{build_announcement, build_attestation};

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,7 +259,7 @@ async fn main() -> anyhow::Result<()> {
             SecretKey::from_str(&secret_key)?
         }
     };
-    let keypair = KeyPair::from_secret_key(&secp, secret_key);
+    let keypair = KeyPair::from_secret_key(&secp, &secret_key);
     info!(
         "oracle keypair successfully generated, pubkey is {}",
         keypair.public_key().serialize().encode_hex::<String>()
@@ -328,7 +328,12 @@ async fn main() -> anyhow::Result<()> {
 
             info!("scheduling oracle events for {}", asset_pair);
             // schedule oracle events (announcements/attestations)
-            oracle_scheduler::init(oracle.clone(), secp.clone(), pricefeeds)?;
+            oracle_scheduler::init(
+                oracle.clone(),
+                secp.clone(),
+                pricefeeds,
+                oracle_config.signing_version,
+            )?;
 
             Ok(oracle)
         }))

--- a/src/oracle/mod.rs
+++ b/src/oracle/mod.rs
@@ -51,7 +51,7 @@ impl Oracle {
     }
 }
 
-pub mod oracle_scheduler;
-pub use oracle_scheduler::messaging::EventDescriptor;
+pub use dlc_messages::oracle_msgs::EventDescriptor;
 
+pub mod oracle_scheduler;
 pub mod pricefeeds;

--- a/src/oracle/oracle_scheduler/messaging.rs
+++ b/src/oracle/oracle_scheduler/messaging.rs
@@ -1,290 +1,43 @@
-use lightning::util::ser::{Writeable, Writer};
-use secp256k1_zkp::{
-    hashes::*, schnorr::Signature as SchnorrSignature, ThirtyTwoByteHash,
-    XOnlyPublicKey as SchnorrPublicKey,
-};
-use serde::Deserialize;
-use time::OffsetDateTime;
+use secp256k1_zkp::{hashes::*, ThirtyTwoByteHash};
 
-const ORACLE_ANNOUNCEMENT_MIDSTATE: [u8; 32] = [
+// DLC/oracle/announcement/v0
+const DLC_V0_ANNOUNCEMENT_MIDSTATE: [u8; 32] = [
     0x0f, 0xfb, 0xaf, 0x80, 0xef, 0x9f, 0x3f, 0xe9, 0x8c, 0xe5, 0xd6, 0xa8, 0x7a, 0xad, 0xb4, 0x59,
     0x8f, 0x85, 0xcb, 0x21, 0x3e, 0x32, 0xe3, 0x28, 0xdf, 0x98, 0xfe, 0xdb, 0x00, 0xc9, 0x7c, 0x83,
 ];
 
+// DLC/oracle/attestation/v0
+const DLC_V0_ATTESTATION_MIDSTATE: [u8; 32] = [
+    0xcc, 0xed, 0x66, 0xce, 0x5c, 0x43, 0xb3, 0x63, 0x85, 0x5e, 0x75, 0xe6, 0x63, 0x4b, 0xa5, 0x9c,
+    0x8e, 0x8b, 0xf4, 0x11, 0xf7, 0x23, 0x5a, 0x31, 0x51, 0x73, 0x92, 0x6b, 0xdf, 0xe9, 0x39, 0xb8,
+];
+
 sha256t_hash_newtype!(
-    OracleAnnouncementHash,
-    OracleAnnouncementHashTag,
-    ORACLE_ANNOUNCEMENT_MIDSTATE,
+    DLCV0AnnouncementHash,
+    DLCV0AnnouncementHashTag,
+    DLC_V0_ANNOUNCEMENT_MIDSTATE,
     64,
-    doc = "oracle announcement tagged hash",
+    doc = "DLC v0 announcement tagged hash",
     true
 );
 
-impl ThirtyTwoByteHash for OracleAnnouncementHash {
+impl ThirtyTwoByteHash for DLCV0AnnouncementHash {
     fn into_32(self) -> [u8; 32] {
         self.into_inner()
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct Announcement {
-    pub signature: SchnorrSignature,
-    pub oracle_pubkey: SchnorrPublicKey,
-    pub oracle_event: OracleEvent,
-}
+sha256t_hash_newtype!(
+    DLCV0AttestationHash,
+    DLCV0AttestationHashTag,
+    DLC_V0_ATTESTATION_MIDSTATE,
+    64,
+    doc = "DLC v0 outcome tagged hash",
+    true
+);
 
-#[derive(Clone, Debug)]
-pub struct OracleEvent {
-    pub nonces: Vec<SchnorrPublicKey>,
-    pub maturation: OffsetDateTime,
-    pub event_descriptor: EventDescriptor,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct EventDescriptor {
-    pub base: u16,
-    pub is_signed: bool,
-    pub unit: String,
-    pub precision: i32,
-    pub num_digits: u16,
-}
-
-#[derive(Clone, Debug)]
-pub struct Attestation {
-    pub oracle_pubkey: SchnorrPublicKey,
-    pub signatures: Vec<SchnorrSignature>,
-    pub outcomes: Vec<String>,
-}
-
-impl From<&Announcement> for dlc_messages::oracle_msgs::OracleAnnouncement {
-    fn from(ann: &Announcement) -> Self {
-        let announcement_signature =
-            secp256k1_zkp_5::schnorrsig::Signature::from_slice(ann.signature.as_ref()).unwrap();
-        let oracle_public_key =
-            secp256k1_zkp_5::schnorrsig::PublicKey::from_slice(&ann.oracle_pubkey.serialize())
-                .unwrap();
-        let oracle_event = (&ann.oracle_event).into();
-        Self {
-            announcement_signature,
-            oracle_public_key,
-            oracle_event,
-        }
-    }
-}
-
-impl From<&OracleEvent> for dlc_messages::oracle_msgs::OracleEvent {
-    fn from(event: &OracleEvent) -> Self {
-        let oracle_nonces = event
-            .nonces
-            .iter()
-            .map(|nonce| {
-                secp256k1_zkp_5::schnorrsig::PublicKey::from_slice(&nonce.serialize()).unwrap()
-            })
-            .collect::<Vec<_>>();
-        let event_maturity_epoch = event.maturation.unix_timestamp().try_into().unwrap();
-        let event_descriptor = (&event.event_descriptor).into();
-        Self {
-            oracle_nonces,
-            event_maturity_epoch,
-            event_descriptor,
-            event_id: String::new(), // todo?
-        }
-    }
-}
-
-impl From<&EventDescriptor> for dlc_messages::oracle_msgs::EventDescriptor {
-    fn from(event: &EventDescriptor) -> Self {
-        let base = event.base;
-        let is_signed = event.is_signed;
-        let unit = event.unit.clone();
-        let precision = event.precision;
-        let nb_digits = event.num_digits;
-        let numerical_descriptor = dlc_messages::oracle_msgs::DigitDecompositionEventDescriptor {
-            base,
-            is_signed,
-            unit,
-            precision,
-            nb_digits,
-        };
-        Self::DigitDecompositionEvent(numerical_descriptor)
-    }
-}
-
-impl From<&Attestation> for dlc_messages::oracle_msgs::OracleAttestation {
-    fn from(att: &Attestation) -> Self {
-        let oracle_public_key =
-            secp256k1_zkp_5::schnorrsig::PublicKey::from_slice(&att.oracle_pubkey.serialize())
-                .unwrap();
-        let signatures = att
-            .signatures
-            .iter()
-            .map(|sig| secp256k1_zkp_5::schnorrsig::Signature::from_slice(sig.as_ref()).unwrap())
-            .collect::<Vec<_>>();
-        let outcomes = att.outcomes.to_vec();
-        Self {
-            oracle_public_key,
-            signatures,
-            outcomes,
-        }
-    }
-}
-
-struct BigSize(u64);
-impl Writeable for BigSize {
-    #[inline]
-    fn write<W: Writer>(&self, writer: &mut W) -> std::io::Result<()> {
-        match self.0 {
-            0..=0xFC => (self.0 as u8).write(writer),
-            0xFD..=0xFFFF => {
-                0xFDu8.write(writer)?;
-                (self.0 as u16).write(writer)
-            }
-            0x10000..=0xFFFFFFFF => {
-                0xFEu8.write(writer)?;
-                (self.0 as u32).write(writer)
-            }
-            _ => {
-                0xFFu8.write(writer)?;
-                (self.0 as u64).write(writer)
-            }
-        }
-    }
-}
-
-impl Announcement {
-    pub fn encode(&self) -> Vec<u8> {
-        let mut out = vec![];
-        BigSize(55332_u64).write(&mut out).unwrap();
-        let v = dlc_messages::oracle_msgs::OracleAnnouncement::from(self).encode();
-        BigSize(v.len() as u64).write(&mut out).unwrap();
-        // extend manually for announcement to be consistent w suredbits decoding
-        out.extend_from_slice(&v);
-        out
-    }
-}
-
-impl OracleEvent {
-    pub fn encode(&self) -> Vec<u8> {
-        dlc_messages::oracle_msgs::OracleEvent::from(self).encode()
-    }
-}
-
-impl Attestation {
-    pub fn encode(&self) -> Vec<u8> {
-        let mut out = vec![];
-        BigSize(55400_u64).write(&mut out).unwrap();
-        let mut v = dlc_messages::oracle_msgs::OracleAttestation::from(self).encode();
-
-        // remove duplicate length encoding from tibo's implementation
-        let end = v.len() - 36;
-        v.drain(end - 2..end);
-
-        BigSize((v.len() + 1) as u64).write(&mut out).unwrap();
-        // extend manually for attestation to be consistent w suredbits decoding
-        // also extend w dummy event id
-        BigSize(0_u64).write(&mut out).unwrap();
-        out.extend_from_slice(&v);
-        out
-    }
-}
-
-// todo: update to test w James' decoding
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use time::format_description::well_known::Rfc3339;
-
-    // does not work yet because suredbits and tibo's implementations must be unified first
-    #[ignore]
-    #[test]
-    fn suredbits_announcement_encodes_correctly() {
-        let oracle_event = OracleEvent {
-            nonces: vec![
-                "bf0b6c97a9a33f7499511b68b0c1e5a758ad51df9330b4b6d4fd841af141bb91",
-                "5d25e99260cec3e1a74257aa1edffbb2c718091d8eecd77f7dd078c69782938e",
-                "6b49f9c7b8b7aa815f2c2d646a0fffd713491a6af3506aa83b3eb7122a1a502d",
-                "2a2a83f8121013eeb1131f6f6b805e79f6cc066cae938d7873a5979d2f4888ce",
-                "0b6d548fa7fff606ec1d3668f4f407da02e3ed3090919a77c5efcb25874c1102",
-                "ac38396a26028d6e4203b6bb684b49bf95c5a67fe126a46cdd0c5287f1c37799",
-                "88059ddfddc40bd7d4bd03f59d2df492f903b45557d6382c5e3931a34ebd175e",
-                "32c1cc1b591cafb4fa6065948300e485d939bf405128dcc096eca3f4d5b68d6c",
-                "0d77575d4c7342025e04f4de78f188808a85ebb3791a75c34ebdcd54104f8a73",
-                "86e831876500d92aefe123c511b003c5aaee355a47ee076685687ca3549d5ccb",
-                "15c56b9e1ad5e300888671ba60e16fc4c2b77617982e42ab401a1f313834b7d1",
-                "7785aed84409206be3b0e62d8f735466007aa1d3709015506d31f497de0eaa43",
-                "b8530f83ae8bf455069d4754847512de24892a789a3bc90904255ebd27ee78cd",
-                "c68b2063ee08249682665644146af85f375f4967d5693cbc7473286180ad8629",
-                "0bd0d39fbb1846496cd7acb8bde77131fb1a2ecd8b2430bf84e61e13bd1b6d7d",
-                "3cd13b98d0ebf476b1ab067135e8d70334bc72ff454b617d48d0851ba01b4b32",
-                "7b37e1c81bafed68ae1f951dc340ae6cd036b67212847aed94322d3397d4e233",
-                "5c4e560486f6daa8c6074f258e3a348e2937ecba83fa8d80196f23a486cf0a30",
-            ]
-            .iter()
-            .map(|nonce| SchnorrPublicKey::from_slice(&::hex::decode(nonce).unwrap()).unwrap())
-            .collect(),
-            maturation: OffsetDateTime::parse("2022-04-11T08:00:00Z", &Rfc3339).unwrap(),
-            event_descriptor: EventDescriptor {
-                base: 2,
-                is_signed: false,
-                unit: "BTCUSD".to_string(),
-                precision: 0,
-                num_digits: 18,
-            },
-        };
-
-        let announcement = Announcement {
-            signature: SchnorrSignature::from_slice(
-                &::hex::decode("e15edeeb14a6bfa3995eeb65208c6698690bb497f22446b0505981ec202bcbc8584077c9f7209a2cf7d459c6a891a3eb863a78355868760455845f1a15fd6858").unwrap()
-            ).unwrap(),
-            oracle_pubkey: SchnorrPublicKey::from_slice(&::hex::decode("04ba9838623f02c940d20d7b185d410178cff7990c7fcf19186c7f58c7c4b8de").unwrap()).unwrap(),
-            oracle_event,
-        };
-
-        assert_eq!(
-            ::hex::decode(
-                "fdd824fd02d4e15edeeb14a6bfa3995eeb65208c6698690bb497f22446b0505981ec202bcbc8584077c9f7209a2cf7d459c6a891a3eb863a78355868760455845f1a15fd685804ba9838623f02c940d20d7b185d410178cff7990c7fcf19186c7f58c7c4b8defdd822fd026e0012bf0b6c97a9a33f7499511b68b0c1e5a758ad51df9330b4b6d4fd841af141bb915d25e99260cec3e1a74257aa1edffbb2c718091d8eecd77f7dd078c69782938e6b49f9c7b8b7aa815f2c2d646a0fffd713491a6af3506aa83b3eb7122a1a502d2a2a83f8121013eeb1131f6f6b805e79f6cc066cae938d7873a5979d2f4888ce0b6d548fa7fff606ec1d3668f4f407da02e3ed3090919a77c5efcb25874c1102ac38396a26028d6e4203b6bb684b49bf95c5a67fe126a46cdd0c5287f1c3779988059ddfddc40bd7d4bd03f59d2df492f903b45557d6382c5e3931a34ebd175e32c1cc1b591cafb4fa6065948300e485d939bf405128dcc096eca3f4d5b68d6c0d77575d4c7342025e04f4de78f188808a85ebb3791a75c34ebdcd54104f8a7386e831876500d92aefe123c511b003c5aaee355a47ee076685687ca3549d5ccb15c56b9e1ad5e300888671ba60e16fc4c2b77617982e42ab401a1f313834b7d17785aed84409206be3b0e62d8f735466007aa1d3709015506d31f497de0eaa43b8530f83ae8bf455069d4754847512de24892a789a3bc90904255ebd27ee78cdc68b2063ee08249682665644146af85f375f4967d5693cbc7473286180ad86290bd0d39fbb1846496cd7acb8bde77131fb1a2ecd8b2430bf84e61e13bd1b6d7d3cd13b98d0ebf476b1ab067135e8d70334bc72ff454b617d48d0851ba01b4b327b37e1c81bafed68ae1f951dc340ae6cd036b67212847aed94322d3397d4e2335c4e560486f6daa8c6074f258e3a348e2937ecba83fa8d80196f23a486cf0a306253e000fdd80a100002000642544355534400000000001213446572696269742d4254432d31314150523232"
-            ).unwrap(),
-            announcement.encode(),
-        );
-    }
-
-    // does not work yet because suredbits and tibo's implementations must be unified first
-    #[ignore]
-    #[test]
-    fn suredbits_attestation_encodes_correctly() {
-        let attestation = Attestation {
-            oracle_pubkey: SchnorrPublicKey::from_slice(&::hex::decode("04ba9838623f02c940d20d7b185d410178cff7990c7fcf19186c7f58c7c4b8de").unwrap()).unwrap(),
-            signatures: vec![
-                "bf0b6c97a9a33f7499511b68b0c1e5a758ad51df9330b4b6d4fd841af141bb9195cad468377a389ce8b46d508b16a81ee4a43e074999777717b8208801f41772",
-                "5d25e99260cec3e1a74257aa1edffbb2c718091d8eecd77f7dd078c69782938e233b3c4cbcbcca11b35127d77e35cfffc10f7c09e5cb547b334e71f10fe29c35",
-                "6b49f9c7b8b7aa815f2c2d646a0fffd713491a6af3506aa83b3eb7122a1a502dd6945e7a18e975fba732be0f09d42553f16bee156896dca058e8aeafb9609b9b",
-                "2a2a83f8121013eeb1131f6f6b805e79f6cc066cae938d7873a5979d2f4888cedbd8dafecccbfd279056c3b9e6b4cb981fd8a76ba5a0cd835bd514d357cdae5f",
-                "0b6d548fa7fff606ec1d3668f4f407da02e3ed3090919a77c5efcb25874c11020ea572df9b34d6836b360a014a5523ec11eecf5611e5aa66cea4b9fede0d22fb",
-                "ac38396a26028d6e4203b6bb684b49bf95c5a67fe126a46cdd0c5287f1c37799d6e17cd3e395402885538c1b0f711da9b5879d977ccc7fe4b3c92f789ccae531",
-                "88059ddfddc40bd7d4bd03f59d2df492f903b45557d6382c5e3931a34ebd175e0a061aef29d81c824582f5375dbc6f28edcd8428e3e0b32f31abc98de34cd2fd",
-                "32c1cc1b591cafb4fa6065948300e485d939bf405128dcc096eca3f4d5b68d6c3ba1cbe15e85555143190164296075bd29c468733bfee2dc97205b6a56d2f81e",
-                "0d77575d4c7342025e04f4de78f188808a85ebb3791a75c34ebdcd54104f8a735938c8fa09e89345260dc7e694d79163029285cc0b09379edf179af01a442b07",
-                "86e831876500d92aefe123c511b003c5aaee355a47ee076685687ca3549d5ccb30ca20cf1544862294a87d46d72fb73cc03e483102b12770d86cc157123109bd",
-                "15c56b9e1ad5e300888671ba60e16fc4c2b77617982e42ab401a1f313834b7d1afe18b838fe7a9ee6e6f5edf10eec22cdbfa8ca619ad91987a6012f472b19941",
-                "7785aed84409206be3b0e62d8f735466007aa1d3709015506d31f497de0eaa43e010f31e41525eda44819b5659a24d5d64e99205e7abf81015923ae12e55b085",
-                "b8530f83ae8bf455069d4754847512de24892a789a3bc90904255ebd27ee78cdb5da94763dda5c30e5d218779a99ff5272237d9e00f3b19cf2870715f84dd8fe",
-                "c68b2063ee08249682665644146af85f375f4967d5693cbc7473286180ad8629efa8cb6bc07194b0b1bead68891c95e80977eb9e0e6d4a2c88f8dbd1629df6d7",
-                "0bd0d39fbb1846496cd7acb8bde77131fb1a2ecd8b2430bf84e61e13bd1b6d7d4b22c794c83623922ae658d94ea2910af92b858f57222038dbe788cba48e202e",
-                "3cd13b98d0ebf476b1ab067135e8d70334bc72ff454b617d48d0851ba01b4b32415ae5a55f8f2a594dcfd92d8a737a0f8c49f05d2040d29cd26d06075884d231",
-                "7b37e1c81bafed68ae1f951dc340ae6cd036b67212847aed94322d3397d4e233fe6988151ded6eef0a57cc0e76a80d54c61ccedf179ebfb41f4fe9f2355fb3d8",
-                "5c4e560486f6daa8c6074f258e3a348e2937ecba83fa8d80196f23a486cf0a30e8bc2a1eeb140c04e132c02ef69a81e88e73582a8be4b788ffd0aef4a1113dad" 
-            ]
-            .iter()
-            .map(|signature| SchnorrSignature::from_slice(&::hex::decode(signature).unwrap()).unwrap())
-            .collect(),
-            outcomes: vec!["0", "0", "1", "0", "1", "0", "0", "1", "0", "1", "0", "1", "0", "0", "1", "1", "1", "0"].iter().map(ToString::to_string).collect(),
-        };
-
-        assert_eq!(
-            ::hex::decode(
-                "fdd868fd04da13446572696269742d4254432d3131415052323204ba9838623f02c940d20d7b185d410178cff7990c7fcf19186c7f58c7c4b8de0012bf0b6c97a9a33f7499511b68b0c1e5a758ad51df9330b4b6d4fd841af141bb9195cad468377a389ce8b46d508b16a81ee4a43e074999777717b8208801f417725d25e99260cec3e1a74257aa1edffbb2c718091d8eecd77f7dd078c69782938e233b3c4cbcbcca11b35127d77e35cfffc10f7c09e5cb547b334e71f10fe29c356b49f9c7b8b7aa815f2c2d646a0fffd713491a6af3506aa83b3eb7122a1a502dd6945e7a18e975fba732be0f09d42553f16bee156896dca058e8aeafb9609b9b2a2a83f8121013eeb1131f6f6b805e79f6cc066cae938d7873a5979d2f4888cedbd8dafecccbfd279056c3b9e6b4cb981fd8a76ba5a0cd835bd514d357cdae5f0b6d548fa7fff606ec1d3668f4f407da02e3ed3090919a77c5efcb25874c11020ea572df9b34d6836b360a014a5523ec11eecf5611e5aa66cea4b9fede0d22fbac38396a26028d6e4203b6bb684b49bf95c5a67fe126a46cdd0c5287f1c37799d6e17cd3e395402885538c1b0f711da9b5879d977ccc7fe4b3c92f789ccae53188059ddfddc40bd7d4bd03f59d2df492f903b45557d6382c5e3931a34ebd175e0a061aef29d81c824582f5375dbc6f28edcd8428e3e0b32f31abc98de34cd2fd32c1cc1b591cafb4fa6065948300e485d939bf405128dcc096eca3f4d5b68d6c3ba1cbe15e85555143190164296075bd29c468733bfee2dc97205b6a56d2f81e0d77575d4c7342025e04f4de78f188808a85ebb3791a75c34ebdcd54104f8a735938c8fa09e89345260dc7e694d79163029285cc0b09379edf179af01a442b0786e831876500d92aefe123c511b003c5aaee355a47ee076685687ca3549d5ccb30ca20cf1544862294a87d46d72fb73cc03e483102b12770d86cc157123109bd15c56b9e1ad5e300888671ba60e16fc4c2b77617982e42ab401a1f313834b7d1afe18b838fe7a9ee6e6f5edf10eec22cdbfa8ca619ad91987a6012f472b199417785aed84409206be3b0e62d8f735466007aa1d3709015506d31f497de0eaa43e010f31e41525eda44819b5659a24d5d64e99205e7abf81015923ae12e55b085b8530f83ae8bf455069d4754847512de24892a789a3bc90904255ebd27ee78cdb5da94763dda5c30e5d218779a99ff5272237d9e00f3b19cf2870715f84dd8fec68b2063ee08249682665644146af85f375f4967d5693cbc7473286180ad8629efa8cb6bc07194b0b1bead68891c95e80977eb9e0e6d4a2c88f8dbd1629df6d70bd0d39fbb1846496cd7acb8bde77131fb1a2ecd8b2430bf84e61e13bd1b6d7d4b22c794c83623922ae658d94ea2910af92b858f57222038dbe788cba48e202e3cd13b98d0ebf476b1ab067135e8d70334bc72ff454b617d48d0851ba01b4b32415ae5a55f8f2a594dcfd92d8a737a0f8c49f05d2040d29cd26d06075884d2317b37e1c81bafed68ae1f951dc340ae6cd036b67212847aed94322d3397d4e233fe6988151ded6eef0a57cc0e76a80d54c61ccedf179ebfb41f4fe9f2355fb3d85c4e560486f6daa8c6074f258e3a348e2937ecba83fa8d80196f23a486cf0a30e8bc2a1eeb140c04e132c02ef69a81e88e73582a8be4b788ffd0aef4a1113dad013001300131013001310130013001310130013101300131013001300131013101310130"
-            ).unwrap(),
-            attestation.encode(),
-        );
+impl ThirtyTwoByteHash for DLCV0AttestationHash {
+    fn into_32(self) -> [u8; 32] {
+        self.into_inner()
     }
 }

--- a/src/oracle/oracle_scheduler/mod.rs
+++ b/src/oracle/oracle_scheduler/mod.rs
@@ -165,8 +165,7 @@ impl OracleScheduler {
             );
 
             let mut attestation_bytes = Vec::new();
-            attestation
-                .write(&mut attestation_bytes)
+            write_as_tlv(&attestation, &mut attestation_bytes)
                 .expect("Error writing attestation");
 
             db_value.2 = Some(attestation_bytes);
@@ -348,8 +347,7 @@ fn create_event(
     )?;
 
     let mut announcement_bytes = Vec::new();
-    announcement
-        .write(&mut announcement_bytes)
+    write_as_tlv(&announcement, &mut announcement_bytes)
         .expect("Error writing announcement");
 
     let db_value = DbValue(Some(outstanding_sk_nonces), announcement_bytes, None, None);

--- a/src/oracle/oracle_scheduler/mod.rs
+++ b/src/oracle/oracle_scheduler/mod.rs
@@ -165,8 +165,7 @@ impl OracleScheduler {
             );
 
             let mut attestation_bytes = Vec::new();
-            write_as_tlv(&attestation, &mut attestation_bytes)
-                .expect("Error writing attestation");
+            write_as_tlv(&attestation, &mut attestation_bytes).expect("Error writing attestation");
 
             db_value.2 = Some(attestation_bytes);
             db_value.3 = Some(avg_price);
@@ -347,8 +346,7 @@ fn create_event(
     )?;
 
     let mut announcement_bytes = Vec::new();
-    write_as_tlv(&announcement, &mut announcement_bytes)
-        .expect("Error writing announcement");
+    write_as_tlv(&announcement, &mut announcement_bytes).expect("Error writing announcement");
 
     let db_value = DbValue(Some(outstanding_sk_nonces), announcement_bytes, None, None);
     info!(
@@ -470,7 +468,7 @@ mod tests {
         let (secret_key, public_key) = secp.generate_keypair(&mut rng);
         (secret_key, public_key)
     }
-    //
+
     fn signatures_to_secret(signatures: &[SchnorrSignature]) -> secp256k1_zkp::SecretKey {
         let s_values: Vec<Scalar> = signatures
             .iter()

--- a/src/oracle/oracle_scheduler/mod.rs
+++ b/src/oracle/oracle_scheduler/mod.rs
@@ -2,11 +2,12 @@ use super::{
     pricefeeds::{PriceFeed, PriceFeedError},
     DbValue, Oracle,
 };
-use crate::AssetPairInfo;
+use crate::{AssetPairInfo, SigningVersion};
 use chrono::Utc;
 use clokwerk::{AsyncScheduler, Interval, Job};
 use core::ptr;
 use futures::{stream, StreamExt};
+use lightning::util::ser::Writeable;
 use log::{error, info};
 use queues::{queue, IsQueue, Queue};
 use secp256k1_sys::{
@@ -32,8 +33,11 @@ mod error;
 pub use error::OracleSchedulerError;
 pub use error::Result;
 
-pub mod messaging;
-use messaging::{Announcement, Attestation, OracleAnnouncementHash, OracleEvent};
+use dlc_messages::oracle_msgs::{OracleAnnouncement, OracleAttestation, OracleEvent};
+use dlc_messages::ser_impls::write_as_tlv;
+
+mod messaging;
+use crate::oracle::oracle_scheduler::messaging::{DLCV0AnnouncementHash, DLCV0AttestationHash};
 
 const SCHEDULER_SLEEP_TIME: std::time::Duration = std::time::Duration::from_millis(100);
 
@@ -86,6 +90,7 @@ struct OracleScheduler {
     db_values: Queue<DbValue>,
     next_announcement: OffsetDateTime,
     next_attestation: OffsetDateTime,
+    signing_version: SigningVersion,
 }
 
 impl OracleScheduler {
@@ -96,12 +101,13 @@ impl OracleScheduler {
             &self.secp,
             &mut self.db_values,
             self.next_announcement + announcement_offset,
+            self.signing_version,
         )?;
         self.next_announcement += self.oracle.oracle_config.frequency;
         Ok(())
     }
 
-    async fn attest(&mut self) -> Result<()> {
+    async fn attest(&mut self, signing_version: SigningVersion) -> Result<()> {
         info!("retrieving pricefeeds for attestation");
         let prices = stream::iter(self.pricefeeds.iter())
             .then(|pricefeed| async {
@@ -120,8 +126,7 @@ impl OracleScheduler {
             .collect::<Vec<Option<f64>>>()
             .await
             .into_iter()
-            .filter(|p| p.is_some())
-            .map(|p| p.unwrap())
+            .flatten()
             .collect::<Vec<f64>>();
 
         if prices.is_empty() {
@@ -149,16 +154,22 @@ impl OracleScheduler {
                 .remove()
                 .expect("db_values should never be empty");
             let attestation = build_attestation(
-                db_value
+                &db_value
                     .0
                     .take()
                     .expect("immature db_values should always have outstanding_sk_nonces"),
                 &self.oracle.keypair,
                 &self.secp,
                 outcomes,
+                signing_version,
             );
 
-            db_value.2 = Some(attestation.encode());
+            let mut attestation_bytes = Vec::new();
+            attestation
+                .write(&mut attestation_bytes)
+                .expect("Error writing attestation");
+
+            db_value.2 = Some(attestation_bytes);
             db_value.3 = Some(avg_price);
             info!(
                 "attesting with maturation {} and attestation {:#?}",
@@ -178,12 +189,13 @@ pub fn init(
     oracle: Oracle,
     secp: Secp256k1<All>,
     pricefeeds: Vec<Box<dyn PriceFeed + Send + Sync>>,
+    signing_version: SigningVersion,
 ) -> Result<()> {
     // start event creation task
     info!("creating oracle events and schedules");
     tokio::spawn(async move {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        if let Err(err) = create_events(oracle, secp, pricefeeds, tx) {
+        if let Err(err) = create_events(oracle, secp, pricefeeds, tx, signing_version) {
             error!("oracle scheduler create_events error: {}", err);
         } else {
             while let Some(err) = rx.recv().await {
@@ -201,6 +213,7 @@ fn create_events(
     secp: Secp256k1<All>,
     pricefeeds: Vec<Box<dyn PriceFeed + Send + Sync>>,
     error_transmitter: mpsc::UnboundedSender<OracleSchedulerError>,
+    signing_version: SigningVersion,
 ) -> Result<()> {
     let now = OffsetDateTime::now_utc();
     let mut next_attestation = now.replace_time(oracle.oracle_config.attestation_time);
@@ -217,7 +230,13 @@ fn create_events(
             .event_database
             .get(next_attestation.format(&Rfc3339).unwrap())?
         {
-            None => create_event(&mut oracle, &secp, &mut db_values, next_attestation)?,
+            None => create_event(
+                &mut oracle,
+                &secp,
+                &mut db_values,
+                next_attestation,
+                signing_version,
+            )?,
             Some(val) => {
                 info!(
                     "existing oracle event found in db with maturation {}, skipping creation",
@@ -237,6 +256,7 @@ fn create_events(
         db_values,
         next_announcement,
         next_attestation,
+        signing_version,
     }));
     info!(
         "created new oracle scheduler with\n\tannouncements at {}\n\tattestations at {}\n\tfrequency of {}\n\tnext announcement at {}\n\tnext attestation at {}",
@@ -290,7 +310,12 @@ fn create_events(
             let oracle_scheduler_clone = oracle_scheduler.clone();
             let error_transmitter_clone = error_transmitter.clone();
             async move {
-                if let Err(err) = oracle_scheduler_clone.lock().await.attest().await {
+                if let Err(err) = oracle_scheduler_clone
+                    .lock()
+                    .await
+                    .attest(signing_version)
+                    .await
+                {
                     info!("error from attestation scheduler");
                     error_transmitter_clone.send(err).unwrap();
                 }
@@ -312,16 +337,22 @@ fn create_event(
     secp: &Secp256k1<All>,
     db_values: &mut Queue<DbValue>,
     maturation: OffsetDateTime,
+    signing_version: SigningVersion,
 ) -> Result<()> {
-    let (announcement, outstanding_sk_nonces) =
-        build_announcement(&oracle.asset_pair_info, &oracle.keypair, secp, maturation)?;
+    let (announcement, outstanding_sk_nonces) = build_announcement(
+        &oracle.asset_pair_info,
+        &oracle.keypair,
+        secp,
+        maturation,
+        signing_version,
+    )?;
 
-    let db_value = DbValue(
-        Some(outstanding_sk_nonces),
-        announcement.encode(),
-        None,
-        None,
-    );
+    let mut announcement_bytes = Vec::new();
+    announcement
+        .write(&mut announcement_bytes)
+        .expect("Error writing announcement");
+
+    let db_value = DbValue(Some(outstanding_sk_nonces), announcement_bytes, None, None);
     info!(
         "creating oracle event (announcement only) with maturation {} and announcement {:#?}",
         maturation, announcement
@@ -339,33 +370,49 @@ pub fn build_announcement(
     keypair: &KeyPair,
     secp: &Secp256k1<All>,
     maturation: OffsetDateTime,
-) -> Result<(Announcement, Vec<[u8; 32]>)> {
+    signing_version: SigningVersion,
+) -> Result<(OracleAnnouncement, Vec<[u8; 32]>)> {
     let mut rng = rand::thread_rng();
     let digits = asset_pair_info.event_descriptor.num_digits;
     let mut sk_nonces = Vec::with_capacity(digits.into());
-    let mut nonces = Vec::with_capacity(digits.into());
+    let mut oracle_nonces = Vec::with_capacity(digits.into());
     for _ in 0..digits {
         let mut sk_nonce = [0u8; 32];
         rng.fill_bytes(&mut sk_nonce);
         let oracle_r_kp = secp256k1_zkp::KeyPair::from_seckey_slice(secp, &sk_nonce)?;
-        let nonce = SchnorrPublicKey::from_keypair(&oracle_r_kp);
+        let nonce = SchnorrPublicKey::from_keypair(&oracle_r_kp).0;
         sk_nonces.push(sk_nonce);
-        nonces.push(nonce);
+        oracle_nonces.push(nonce);
     }
 
     let oracle_event = OracleEvent {
-        nonces,
-        maturation,
-        event_descriptor: asset_pair_info.event_descriptor.clone(),
+        oracle_nonces,
+        event_maturity_epoch: maturation.unix_timestamp() as u32,
+        event_descriptor: asset_pair_info.clone().event_descriptor.into(),
+        event_id: "".to_string(),
     };
 
+    let msg = match signing_version {
+        SigningVersion::Basic => {
+            let mut event_bytes = Vec::new();
+            oracle_event
+                .write(&mut event_bytes)
+                .expect("Error writing oracle event");
+            Message::from_hashed_data::<sha256::Hash>(&event_bytes)
+        }
+        SigningVersion::DLCv0 => {
+            let mut event_bytes = Vec::new();
+            write_as_tlv(&oracle_event, &mut event_bytes).expect("Error writing oracle event");
+            Message::from_hashed_data::<DLCV0AnnouncementHash>(&event_bytes)
+        }
+    };
+
+    let announcement_signature = secp.sign_schnorr(&msg, keypair);
+
     Ok((
-        Announcement {
-            signature: secp.sign_schnorr(
-                &Message::from_hashed_data::<OracleAnnouncementHash>(&oracle_event.encode()),
-                keypair,
-            ),
-            oracle_pubkey: keypair.public_key(),
+        OracleAnnouncement {
+            announcement_signature,
+            oracle_public_key: keypair.x_only_public_key().0,
             oracle_event,
         },
         sk_nonces,
@@ -373,25 +420,29 @@ pub fn build_announcement(
 }
 
 pub fn build_attestation(
-    outstanding_sk_nonces: Vec<[u8; 32]>,
+    outstanding_sk_nonces: &[[u8; 32]],
     keypair: &KeyPair,
     secp: &Secp256k1<All>,
     outcomes: Vec<String>,
-) -> Attestation {
+    signing_version: SigningVersion,
+) -> OracleAttestation {
     let signatures = outcomes
         .iter()
         .zip(outstanding_sk_nonces.iter())
         .map(|(outcome, outstanding_sk_nonce)| {
-            sign_schnorr_with_nonce(
-                secp,
-                &Message::from_hashed_data::<sha256::Hash>(outcome.as_bytes()),
-                keypair,
-                outstanding_sk_nonce,
-            )
+            let msg = match signing_version {
+                SigningVersion::Basic => {
+                    Message::from_hashed_data::<sha256::Hash>(outcome.as_bytes())
+                }
+                SigningVersion::DLCv0 => {
+                    Message::from_hashed_data::<DLCV0AttestationHash>(outcome.as_bytes())
+                }
+            };
+            sign_schnorr_with_nonce(secp, &msg, keypair, outstanding_sk_nonce)
         })
         .collect::<Vec<_>>();
-    Attestation {
-        oracle_pubkey: keypair.public_key(),
+    OracleAttestation {
+        oracle_public_key: keypair.public_key().x_only_public_key().0,
         signatures,
         outcomes,
     }
@@ -400,85 +451,88 @@ pub fn build_attestation(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{oracle::EventDescriptor, AssetPair};
+    use crate::{AssetPair, SerializableEventDescriptor};
     use dlc::OracleInfo;
+    use dlc_messages::ser_impls::write_as_tlv;
+    use secp256k1::Scalar;
     use secp256k1_zkp::rand::{distributions::Alphanumeric, Rng};
+    use std::fmt::Write as _;
 
     fn setup() -> (KeyPair, Secp256k1<All>) {
         let secp = Secp256k1::new();
         let mut rng = rand::thread_rng();
         let (secret_key, _) = secp.generate_keypair(&mut rng);
-        (KeyPair::from_secret_key(&secp, secret_key), secp)
+        (KeyPair::from_secret_key(&secp, &secret_key), secp)
     }
 
-    fn setup_v5() -> (
-        secp256k1_zkp_5::SecretKey,
-        secp256k1_zkp_5::PublicKey,
-        secp256k1_zkp_5::Secp256k1<secp256k1_zkp_5::All>,
-    ) {
-        let secp = secp256k1_zkp_5::Secp256k1::new();
+    fn setup_adaptor_signatures(
+        secp: &Secp256k1<All>,
+    ) -> (secp256k1_zkp::SecretKey, secp256k1_zkp::PublicKey) {
         let mut rng = rand::thread_rng();
         let (secret_key, public_key) = secp.generate_keypair(&mut rng);
-        (secret_key, public_key, secp)
+        (secret_key, public_key)
     }
-
-    fn signatures_to_secret(signatures: &[SchnorrSignature]) -> secp256k1_zkp_5::SecretKey {
-        let s_values: Vec<&[u8]> = signatures
+    //
+    fn signatures_to_secret(signatures: &[SchnorrSignature]) -> secp256k1_zkp::SecretKey {
+        let s_values: Vec<Scalar> = signatures
             .iter()
             .map(|x| {
                 let bytes = x.as_ref();
-                &bytes[32..64]
+                Scalar::from_le_bytes(bytes[32..64].try_into().unwrap()).unwrap()
             })
             .collect();
-        let mut secret = secp256k1_zkp_5::SecretKey::from_slice(s_values[0]).unwrap();
+        let secret = secp256k1_zkp::SecretKey::from_slice(&s_values[0].to_le_bytes()).unwrap();
         for s in s_values.iter().skip(1) {
-            secret.add_assign(s).unwrap();
+            secret.add_tweak(s).unwrap();
         }
 
         secret
     }
 
+    pub fn hex_str(value: &[u8]) -> String {
+        let mut res = String::with_capacity(64);
+        for v in value {
+            write!(res, "{:02x}", v).unwrap();
+        }
+        res
+    }
+
     #[test]
-    fn announcement_signature_verifies() {
+    fn announcement_signature_verifies_basic() {
         let (keypair, secp) = setup();
+        let announcement = build_test_announcement(&keypair, &secp, SigningVersion::Basic).0;
 
-        let announcement = build_announcement(
-            &AssetPairInfo {
-                asset_pair: AssetPair::BTCUSD,
-                event_descriptor: EventDescriptor {
-                    base: 2,
-                    is_signed: false,
-                    unit: "BTCUSD".to_string(),
-                    precision: 0,
-                    num_digits: 18,
-                },
-                exclude_price_feeds: vec![],
-            },
-            &keypair,
-            &secp,
-            OffsetDateTime::now_utc(),
-        )
-        .unwrap()
-        .0;
+        // let mut announcement_bytes = vec![];
+        // write_as_tlv(&announcement, &mut announcement_bytes).unwrap();
+        // println!("{}", hex_str(&announcement_bytes));
 
-        let tag_hash = sha256::Hash::hash(b"DLC/oracle/announcement/v0");
+        announcement.validate(&secp).unwrap();
+    }
+
+    #[test]
+    fn announcement_signature_verifies_dlc_v0() {
+        let (keypair, secp) = setup();
+        let announcement = build_test_announcement(&keypair, &secp, SigningVersion::DLCv0).0;
+
+        // let mut announcement_bytes = vec![];
+        // write_as_tlv(&announcement, &mut announcement_bytes).unwrap();
+        // println!("{}", hex_str(&announcement_bytes));
+
+        let mut event_bytes = Vec::new();
+        write_as_tlv(&announcement.oracle_event, &mut event_bytes)
+            .expect("Error writing oracle event");
+
+        let msg = Message::from_hashed_data::<DLCV0AnnouncementHash>(&event_bytes);
         secp.verify_schnorr(
-            &announcement.signature,
-            &Message::from_hashed_data::<sha256::Hash>(
-                &[
-                    tag_hash.to_vec(),
-                    tag_hash.to_vec(),
-                    announcement.oracle_event.encode(),
-                ]
-                .concat(),
-            ),
-            &keypair.public_key(),
+            &announcement.announcement_signature,
+            &msg,
+            &announcement.oracle_public_key,
         )
         .unwrap();
     }
 
     #[test]
-    fn attestation_signature_verifies() {
+    fn attestation_signature_verifies_basic() {
         let (keypair, secp) = setup();
 
         let mut outstanding_sk_nonce = vec![[0u8; 32]];
@@ -490,23 +544,118 @@ mod tests {
             .map(char::from)
             .collect();
         let outcome = vec![outcome];
-        let attestation = build_attestation(outstanding_sk_nonce, &keypair, &secp, outcome);
+        let attestation = build_attestation(
+            &outstanding_sk_nonce,
+            &keypair,
+            &secp,
+            outcome,
+            SigningVersion::Basic,
+        );
         secp.verify_schnorr(
             &attestation.signatures[0],
             &Message::from_hashed_data::<sha256::Hash>(attestation.outcomes[0].as_bytes()),
-            &keypair.public_key(),
+            &keypair.public_key().x_only_public_key().0,
         )
         .unwrap();
     }
 
     #[test]
+    fn attestation_signature_verifies_dlc_v0() {
+        let (keypair, secp) = setup();
+
+        let mut outstanding_sk_nonce = vec![[0u8; 32]];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut outstanding_sk_nonce[0]);
+        let outcome = rng
+            .sample_iter(&Alphanumeric)
+            .take(32)
+            .map(char::from)
+            .collect();
+        let outcome = vec![outcome];
+        let attestation = build_attestation(
+            &outstanding_sk_nonce,
+            &keypair,
+            &secp,
+            outcome,
+            SigningVersion::DLCv0,
+        );
+        secp.verify_schnorr(
+            &attestation.signatures[0],
+            &Message::from_hashed_data::<DLCV0AttestationHash>(attestation.outcomes[0].as_bytes()),
+            &keypair.public_key().x_only_public_key().0,
+        )
+        .unwrap();
+    }
+
+    #[ignore]
+    #[test]
     fn valid_adaptor_signature() {
         let (keypair, secp) = setup();
 
+        let (announcement, outstanding_sk_nonces) =
+            build_test_announcement(&keypair, &secp, SigningVersion::Basic);
+
+        let outcomes: Vec<String> = vec![
+            "0", "0", "0", "1", "1", "1", "0", "1", "0", "0", "0", "1", "0", "1", "0", "0", "0",
+            "1",
+        ]
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+        let attestation = build_attestation(
+            &outstanding_sk_nonces,
+            &keypair,
+            &secp,
+            outcomes.clone(),
+            SigningVersion::Basic,
+        );
+
+        let (funding_secret_key, funding_public_key) = setup_adaptor_signatures(&secp);
+
+        let adaptor_point = dlc::get_adaptor_point_from_oracle_info(
+            &secp,
+            &[OracleInfo {
+                public_key: keypair.public_key().x_only_public_key().0,
+                nonces: announcement.oracle_event.oracle_nonces,
+            }],
+            &[outcomes
+                .iter()
+                .map(|outcome| Message::from_hashed_data::<sha256::Hash>(outcome.as_bytes()))
+                .collect::<Vec<_>>()],
+        )
+        .unwrap();
+
+        let test_msg = secp256k1_zkp::Message::from_hashed_data::<
+            secp256k1_zkp::hashes::sha256::Hash,
+        >("test".as_bytes());
+        let adaptor_sig = secp256k1_zkp::EcdsaAdaptorSignature::encrypt(
+            &secp,
+            &test_msg,
+            &funding_secret_key,
+            &adaptor_point,
+        );
+
+        adaptor_sig
+            .verify(&secp, &test_msg, &funding_public_key, &adaptor_point)
+            .unwrap();
+
+        let adapted_sig = adaptor_sig
+            .decrypt(&signatures_to_secret(&attestation.signatures))
+            .unwrap();
+
+        secp.verify_ecdsa(&test_msg, &adapted_sig, &funding_public_key)
+            .unwrap();
+    }
+
+    fn build_test_announcement(
+        keypair: &KeyPair,
+        secp: &Secp256k1<All>,
+        signing_version: SigningVersion,
+    ) -> (OracleAnnouncement, Vec<[u8; 32]>) {
         let (announcement, outstanding_sk_nonces) = build_announcement(
             &AssetPairInfo {
                 asset_pair: AssetPair::BTCUSD,
-                event_descriptor: EventDescriptor {
+                event_descriptor: SerializableEventDescriptor {
                     base: 2,
                     is_signed: false,
                     unit: "BTCUSD".to_string(),
@@ -518,69 +667,9 @@ mod tests {
             &keypair,
             &secp,
             OffsetDateTime::now_utc(),
+            signing_version,
         )
         .unwrap();
-
-        let outcomes: Vec<String> = vec![
-            "0", "0", "0", "1", "1", "1", "0", "1", "0", "0", "0", "1", "0", "1", "0", "0", "0",
-            "1",
-        ]
-        .iter()
-        .map(ToString::to_string)
-        .collect();
-        let attestation =
-            build_attestation(outstanding_sk_nonces, &keypair, &secp, outcomes.clone());
-
-        let (funding_secret_key, funding_public_key, secp_5) = setup_v5();
-
-        let adaptor_point = dlc::get_adaptor_point_from_oracle_info(
-            &secp_5,
-            &[OracleInfo {
-                public_key: secp256k1_zkp_5::schnorrsig::PublicKey::from_slice(
-                    &keypair.public_key().serialize(),
-                )
-                .unwrap(),
-                nonces: announcement
-                    .oracle_event
-                    .nonces
-                    .iter()
-                    .map(|nonce| {
-                        secp256k1_zkp_5::schnorrsig::PublicKey::from_slice(&nonce.serialize())
-                            .unwrap()
-                    })
-                    .collect(),
-            }],
-            &[outcomes
-                .iter()
-                .map(|outcome| {
-                    secp256k1_zkp_5::Message::from_hashed_data::<
-                        secp256k1_zkp_5::bitcoin_hashes::sha256::Hash,
-                    >(outcome.as_bytes())
-                })
-                .collect::<Vec<_>>()],
-        )
-        .unwrap();
-
-        let test_msg = secp256k1_zkp_5::Message::from_hashed_data::<
-            secp256k1_zkp_5::bitcoin_hashes::sha256::Hash,
-        >("test".as_bytes());
-        let adaptor_sig = secp256k1_zkp_5::EcdsaAdaptorSignature::encrypt(
-            &secp_5,
-            &test_msg,
-            &funding_secret_key,
-            &adaptor_point,
-        );
-
-        adaptor_sig
-            .verify(&secp_5, &test_msg, &funding_public_key, &adaptor_point)
-            .unwrap();
-
-        let adapted_sig = adaptor_sig
-            .decrypt(&signatures_to_secret(&attestation.signatures))
-            .unwrap();
-
-        secp_5
-            .verify(&test_msg, &adapted_sig, &funding_public_key)
-            .unwrap();
+        (announcement, outstanding_sk_nonces)
     }
 }

--- a/src/oracle/pricefeeds/mod.rs
+++ b/src/oracle/pricefeeds/mod.rs
@@ -19,7 +19,7 @@ pub trait PriceFeed {
     async fn retrieve_price(&self, asset_pair: AssetPair, datetime: OffsetDateTime) -> Result<f64>;
 }
 
-pub static ALL_PRICE_FEEDS: &'static [&str] = &["bitstamp", "gateio", "kraken"];
+pub static ALL_PRICE_FEEDS: &[&str] = &["bitstamp", "gateio", "kraken"];
 
 pub fn create_price_feed(feed_id: &str) -> Result<Box<dyn PriceFeed + Send + Sync>> {
     match feed_id {


### PR DESCRIPTION
This PR implements two signing schemes: the basic one (deprecated, should be used for backward compatibility), and [DLC signing scheme v0](https://github.com/discreetlogcontracts/dlcspecs/blob/master/Oracle.md#signing-algorithm). They are configurable in `oracle.json`.