### PR TITLE
Implement Deribit pricefeed

### DIFF
--- a/src/oracle/pricefeeds/bitfinex.rs
+++ b/src/oracle/pricefeeds/bitfinex.rs
@@ -15,16 +15,16 @@ impl PriceFeed for Bitfinex {
         "bitfinex"
     }
 
-    fn translate_asset_pair(&self, asset_pair: AssetPair) -> &'static str {
+    fn translate_asset_pair(&self, asset_pair: AssetPair) -> Result<&'static str> {
         match asset_pair {
-            AssetPair::BTCUSD => "tBTCUSD",
-            AssetPair::BTCUSDT => "tBTCUST",
+            AssetPair::BTCUSD => Ok("tBTCUSD"),
+            AssetPair::BTCUSDT => Ok("tBTCUST"),
         }
     }
 
     async fn retrieve_price(&self, asset_pair: AssetPair, instant: OffsetDateTime) -> Result<f64> {
         let client = Client::new();
-        let asset_pair_translation = self.translate_asset_pair(asset_pair);
+        let asset_pair_translation = self.translate_asset_pair(asset_pair).unwrap();
         let start_time: i64 = instant.unix_timestamp();
 
         info!("sending bitfinex http request");

--- a/src/oracle/pricefeeds/bitstamp.rs
+++ b/src/oracle/pricefeeds/bitstamp.rs
@@ -32,16 +32,16 @@ impl PriceFeed for Bitstamp {
         "bitstamp"
     }
 
-    fn translate_asset_pair(&self, asset_pair: AssetPair) -> &'static str {
+    fn translate_asset_pair(&self, asset_pair: AssetPair) -> Result<&'static str> {
         match asset_pair {
-            AssetPair::BTCUSD => "btcusd",
-            AssetPair::BTCUSDT => "btcusdt",
+            AssetPair::BTCUSD => Ok("btcusd"),
+            AssetPair::BTCUSDT => Ok("btcusdt"),
         }
     }
 
     async fn retrieve_price(&self, asset_pair: AssetPair, instant: OffsetDateTime) -> Result<f64> {
         let client = Client::new();
-        let asset_pair_translation = self.translate_asset_pair(asset_pair);
+        let asset_pair_translation = self.translate_asset_pair(asset_pair).unwrap();
         let start_time = instant.unix_timestamp();
         info!("sending bitstamp http request");
         let res: Response = client

--- a/src/oracle/pricefeeds/deribit.rs
+++ b/src/oracle/pricefeeds/deribit.rs
@@ -1,0 +1,97 @@
+use super::{PriceFeed, PriceFeedError, Result};
+use crate::AssetPair;
+use reqwest::Client;
+use serde::Deserialize;
+use time::OffsetDateTime;
+use serde_json::Value;
+use log::info;
+
+#[derive(Deserialize, Debug)]
+struct Response {
+    result: Option<DeribitResult>,
+    error: Option<Value>,
+}
+
+#[derive(Deserialize, Debug)]
+struct DeribitResult {
+    settlements: Vec<DeribitSettlement>,
+}
+
+#[derive(Deserialize, Debug)]
+struct DeribitSettlement {
+    index_price: f64,
+}
+
+use async_trait::async_trait;
+
+pub struct Deribit {}
+
+#[async_trait]
+impl PriceFeed for Deribit {
+    fn id(&self) -> &'static str {
+        "deribit"
+    }
+
+    fn translate_asset_pair(&self, asset_pair: AssetPair) -> Result<&'static str> {
+        match asset_pair {
+            AssetPair::BTCUSD => Ok("BTC"),
+            AssetPair::BTCUSDT => return Err(PriceFeedError::InternalError(format!("deribit does not support USDT"))),
+        }
+    }
+
+    async fn retrieve_price(&self, asset_pair: AssetPair, instant: OffsetDateTime) -> Result<f64> {
+        let client = Client::new();
+        let asset_pair_translation = self.translate_asset_pair(asset_pair).unwrap();
+        let start_time = instant.unix_timestamp() * 1000;
+        info!("sending deribit http request");
+        let res: Response = client
+            .get("https://www.deribit.com/api/v2/public/get_last_settlements_by_currency")
+            .query(&[
+                ("currency", asset_pair_translation),
+                ("type", "delivery"),
+                ("count", "1"),
+                ("search_start_timestamp", &start_time.to_string()),
+            ])
+            .send()
+            .await?
+            .json()
+            .await?;
+        
+        info!("received response: {:#?}", res);
+
+        if let Some(error) = res.error {
+            return Err(PriceFeedError::InternalError(format!(
+                "deribit error: {:#?}",
+                error
+            )));
+        }
+
+        let res = res
+            .result
+            .ok_or(PriceFeedError::PriceNotAvailableError(asset_pair, instant))?;
+
+        let index_price = res.settlements[0].index_price;
+        Ok(index_price)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::OffsetDateTime;
+
+    #[tokio::test]
+    async fn test_retrieve_price() {
+        let deribit = Deribit {};
+        let now = OffsetDateTime::now_utc();
+        let result = deribit.retrieve_price(AssetPair::BTCUSD, now).await;
+
+        match result {
+            Ok(price) => {
+                println!("The price is: {}", price);
+                assert!(price > 0.0);
+            }
+            Err(e) => panic!("API call failed with error: {:?}", e),
+        }
+    }
+}

--- a/src/oracle/pricefeeds/gateio.rs
+++ b/src/oracle/pricefeeds/gateio.rs
@@ -14,10 +14,10 @@ impl PriceFeed for GateIo {
         "gateio"
     }
 
-    fn translate_asset_pair(&self, asset_pair: AssetPair) -> &'static str {
+    fn translate_asset_pair(&self, asset_pair: AssetPair) -> Result<&'static str> {
         match asset_pair {
-            AssetPair::BTCUSD => "BTC_USD",
-            AssetPair::BTCUSDT => "BTC_USDT",
+            AssetPair::BTCUSD => Ok("BTC_USD"),
+            AssetPair::BTCUSDT => Ok("BTC_USDT"),
         }
     }
 
@@ -28,7 +28,7 @@ impl PriceFeed for GateIo {
         let res: Vec<Vec<Value>> = client
             .get("https://api.gateio.ws/api/v4/spot/candlesticks")
             .query(&[
-                ("currency_pair", self.translate_asset_pair(asset_pair)),
+                ("currency_pair", self.translate_asset_pair(asset_pair).unwrap()),
                 ("from", &start_time.to_string()),
                 ("limit", "1"),
             ])

--- a/src/oracle/pricefeeds/kraken.rs
+++ b/src/oracle/pricefeeds/kraken.rs
@@ -25,16 +25,16 @@ impl PriceFeed for Kraken {
         "kraken"
     }
 
-    fn translate_asset_pair(&self, asset_pair: AssetPair) -> &'static str {
+    fn translate_asset_pair(&self, asset_pair: AssetPair) -> Result<&'static str> {
         match asset_pair {
-            AssetPair::BTCUSD => "XXBTZUSD",
-            AssetPair::BTCUSDT => "XXBTZUSDT",
+            AssetPair::BTCUSD => Ok("XXBTZUSD"),
+            AssetPair::BTCUSDT => Ok("XXBTZUSDT"),
         }
     }
 
     async fn retrieve_price(&self, asset_pair: AssetPair, instant: OffsetDateTime) -> Result<f64> {
         let client = Client::new();
-        let asset_pair_translation = self.translate_asset_pair(asset_pair);
+        let asset_pair_translation = self.translate_asset_pair(asset_pair).unwrap();
         let start_time = instant.unix_timestamp();
         info!("sending kraken http request");
         let res: Response = client

--- a/src/oracle/pricefeeds/mod.rs
+++ b/src/oracle/pricefeeds/mod.rs
@@ -7,6 +7,7 @@ pub use error::PriceFeedError;
 pub use error::Result;
 pub use gateio::GateIo;
 pub use kraken::Kraken;
+pub use deribit::Deribit;
 
 use crate::oracle::pricefeeds::PriceFeedError::InternalError;
 use crate::AssetPair;
@@ -16,11 +17,11 @@ mod error;
 #[async_trait]
 pub trait PriceFeed {
     fn id(&self) -> &'static str;
-    fn translate_asset_pair(&self, asset_pair: AssetPair) -> &'static str;
+    fn translate_asset_pair(&self, asset_pair: AssetPair) -> Result<&'static str>;
     async fn retrieve_price(&self, asset_pair: AssetPair, datetime: OffsetDateTime) -> Result<f64>;
 }
 
-pub static ALL_PRICE_FEEDS: &[&str] = &["bitstamp", "gateio", "kraken", "bitfinex"];
+pub static ALL_PRICE_FEEDS: &[&str] = &["bitstamp", "gateio", "kraken", "bitfinex", "deribit"];
 
 pub fn create_price_feed(feed_id: &str) -> Result<Box<dyn PriceFeed + Send + Sync>> {
     match feed_id {
@@ -28,6 +29,7 @@ pub fn create_price_feed(feed_id: &str) -> Result<Box<dyn PriceFeed + Send + Syn
         "gateio" => Ok(Box::new(GateIo {})),
         "kraken" => Ok(Box::new(Kraken {})),
         "bitfinex" => Ok(Box::new(Bitfinex {})),
+        "deribit" => Ok(Box::new(Deribit {})),
         _ => Err(InternalError(format!("unknown price feed {}", feed_id))),
     }
 }
@@ -36,3 +38,4 @@ mod bitfinex;
 mod bitstamp;
 mod gateio;
 mod kraken;
+mod deribit;


### PR DESCRIPTION
Add the Deribit API as an additional price feed data source

Note: Deribit only supports USD, not USDT