### PR TITLE
Implemented a median price calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ There are three configurable parameters for the oracle:
 | `attestation_time`    | `([0-1][0-9]\|2[0-3]):[0-5][0-9]`                                                                                                                                            | time of attestation, in 24-hour format                                                                                |
 | `frequency`           | `(\d+(nsec\|ns\|usec\|us\|msec\|ms\|seconds\|second\|sec\|s\|minutes\|minute\|min\|m\|hours\|hour\|hr\|h\|days\|day\|d\|weeks\|week\|w\|months\|month\|M\|years\|year\|y))+` | frequency of attestation                                                                                              |
 | `announcement_offset` | `(\d+(nsec\|ns\|usec\|us\|msec\|ms\|seconds\|second\|sec\|s\|minutes\|minute\|min\|m\|hours\|hour\|hr\|h\|days\|day\|d\|weeks\|week\|w\|months\|month\|M\|years\|year\|y))+` | offset from attestation for announcement, e.g. with an offset of `5h` announcements happen at `attestation_time - 5h` |
-| `price_aggregation_type` | `(avg|median)` | method for aggregating prices collected from pricefeeds |
+| `price_aggregation_type` | `(avg\|median)` | method for aggregating prices collected from pricefeeds |
 
 The program defaults are located in `config/oracle.json`.
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ There are three configurable parameters for the oracle:
 | `attestation_time`    | `([0-1][0-9]\|2[0-3]):[0-5][0-9]`                                                                                                                                            | time of attestation, in 24-hour format                                                                                |
 | `frequency`           | `(\d+(nsec\|ns\|usec\|us\|msec\|ms\|seconds\|second\|sec\|s\|minutes\|minute\|min\|m\|hours\|hour\|hr\|h\|days\|day\|d\|weeks\|week\|w\|months\|month\|M\|years\|year\|y))+` | frequency of attestation                                                                                              |
 | `announcement_offset` | `(\d+(nsec\|ns\|usec\|us\|msec\|ms\|seconds\|second\|sec\|s\|minutes\|minute\|min\|m\|hours\|hour\|hr\|h\|days\|day\|d\|weeks\|week\|w\|months\|month\|M\|years\|year\|y))+` | offset from attestation for announcement, e.g. with an offset of `5h` announcements happen at `attestation_time - 5h` |
+| `price_aggregation_type` | `(avg|median)` | method for aggregating prices collected from pricefeeds |
 
 The program defaults are located in `config/oracle.json`.
 

--- a/config/oracle.json
+++ b/config/oracle.json
@@ -2,5 +2,6 @@
     "attestation_time": "08:00",
     "frequency": "1d",
     "announcement_offset": "7d8h",
-    "signing_version": "dlc_v0"
+    "signing_version": "dlc_v0",
+    "price_aggregation_type": "avg"
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -127,6 +127,14 @@ pub enum SigningVersion {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub enum AggregationType {
+    #[serde(rename = "avg")]
+    Average,
+    #[serde(rename = "median")]
+    Median,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct OracleConfig {
     #[serde(with = "standard_time")]
     pub attestation_time: Time,
@@ -135,4 +143,5 @@ pub struct OracleConfig {
     #[serde(with = "standard_duration")]
     pub announcement_offset: Duration,
     pub signing_version: SigningVersion,
+    pub price_aggregation_type: AggregationType,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,6 +333,7 @@ async fn main() -> anyhow::Result<()> {
                 secp.clone(),
                 pricefeeds,
                 oracle_config.signing_version,
+                oracle_config.price_aggregation_type,
             )?;
 
             Ok(oracle)


### PR DESCRIPTION
Added the `price_aggregation_type` parameter to `oracle.json` which can aggregate the prices from the pricefeeds by median or by average.

Fixes https://github.com/lava-xyz/sibyls/issues/9