### PR TITLE
Chore/refactor price feed utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+test-feed = []
+
 [dependencies]
 actix-web = "4.0.1"
 anyhow = "1.0.57"

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display, Formatter};
 use time::{serde::format_description, Duration, Time};
 
+use crate::oracle::pricefeeds::FeedId;
+
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum AssetPair {
     BTCUSD,
@@ -56,8 +58,8 @@ impl From<SerializableEventDescriptor> for EventDescriptor {
 pub struct AssetPairInfo {
     pub asset_pair: AssetPair,
     pub event_descriptor: SerializableEventDescriptor,
-    pub include_price_feeds: Vec<String>,
-    pub exclude_price_feeds: Vec<String>,
+    pub include_price_feeds: Vec<FeedId>,
+    pub exclude_price_feeds: Vec<FeedId>,
 }
 
 impl Display for AssetPair {
@@ -145,4 +147,47 @@ pub struct OracleConfig {
     pub announcement_offset: Duration,
     pub signing_version: SigningVersion,
     pub price_aggregation_type: AggregationType,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::AssetPairInfo;
+
+    #[cfg(not(feature = "test-feed"))]
+    const TEST_INFO: &str = r#"
+{
+    "asset_pair": "BTCUSD",
+    "event_descriptor": {
+        "base": 2,
+        "is_signed": false,
+        "unit": "BTCUSD",
+        "precision": 0,
+        "num_digits": 18
+    },
+    "include_price_feeds": ["Bitfinex", "Kraken"],
+    "exclude_price_feeds": ["GateIO"]
+}
+    "#;
+
+    #[cfg(feature = "test-feed")]
+    const TEST_INFO: &str = r#"
+{
+    "asset_pair": "BTCUSD",
+    "event_descriptor": {
+        "base": 2,
+        "is_signed": false,
+        "unit": "BTCUSD",
+        "precision": 0,
+        "num_digits": 18
+    },
+    "include_price_feeds": ["Test"],
+    "exclude_price_feeds": []
+}
+    "#;
+
+    #[test]
+    fn parse_config_no_error() {
+        let _: AssetPairInfo =
+            serde_json::from_str(TEST_INFO).expect("To be able to parse the configuration.");
+    }
 }

--- a/src/oracle/oracle_scheduler/mod.rs
+++ b/src/oracle/oracle_scheduler/mod.rs
@@ -454,7 +454,6 @@ mod tests {
     use dlc_messages::ser_impls::write_as_tlv;
     use secp256k1::Scalar;
     use secp256k1_zkp::rand::{distributions::Alphanumeric, Rng};
-    use std::fmt::Write as _;
 
     fn setup() -> (KeyPair, Secp256k1<All>) {
         let secp = Secp256k1::new();
@@ -485,14 +484,6 @@ mod tests {
         }
 
         secret
-    }
-
-    pub fn hex_str(value: &[u8]) -> String {
-        let mut res = String::with_capacity(64);
-        for v in value {
-            write!(res, "{:02x}", v).unwrap();
-        }
-        res
     }
 
     #[test]

--- a/src/oracle/pricefeeds/bitfinex.rs
+++ b/src/oracle/pricefeeds/bitfinex.rs
@@ -52,8 +52,9 @@ impl PriceFeed for Bitfinex {
     }
 }
 
+#[cfg(test)]
 mod tests {
-    use crate::AssetPair::*;
+    use crate::AssetPair::BTCUSD;
 
     use super::*;
 

--- a/src/oracle/pricefeeds/mod.rs
+++ b/src/oracle/pricefeeds/mod.rs
@@ -1,4 +1,8 @@
 use async_trait::async_trait;
+use futures::StreamExt;
+use log::{error, info};
+use serde::Deserialize;
+use serde::Serialize;
 use time::OffsetDateTime;
 
 pub use bitfinex::Bitfinex;
@@ -8,9 +12,10 @@ pub use error::PriceFeedError;
 pub use error::Result;
 pub use gateio::GateIo;
 pub use kraken::Kraken;
+#[cfg(feature = "test-feed")]
 pub use test_feed::TestFeed;
 
-use crate::oracle::pricefeeds::PriceFeedError::InternalError;
+use crate::AggregationType;
 use crate::AssetPair;
 
 mod error;
@@ -22,18 +27,125 @@ pub trait PriceFeed {
     async fn retrieve_price(&self, asset_pair: AssetPair, datetime: OffsetDateTime) -> Result<f64>;
 }
 
-pub static ALL_PRICE_FEEDS: &[&str] = &["bitstamp", "gateio", "kraken", "bitfinex", "deribit"];
+#[cfg(not(feature = "test-feed"))]
+pub static ALL_PRICE_FEEDS: &[FeedId] = &[
+    FeedId::Bitstamp,
+    FeedId::GateIO,
+    FeedId::Kraken,
+    FeedId::Bitfinex,
+    FeedId::Deribit,
+];
 
-pub fn create_price_feed(feed_id: &str) -> Result<Box<dyn PriceFeed + Send + Sync>> {
+#[cfg(not(feature = "test-feed"))]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum FeedId {
+    Bitstamp,
+    GateIO,
+    Kraken,
+    Bitfinex,
+    Deribit,
+}
+
+#[cfg(feature = "test-feed")]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum FeedId {
+    Test,
+}
+
+pub struct ParseFeedIdError;
+
+#[cfg(not(feature = "test-feed"))]
+pub fn create_price_feed(feed_id: &FeedId) -> Box<dyn PriceFeed + Send + Sync> {
     match feed_id {
-        "bitstamp" => Ok(Box::new(Bitstamp {})),
-        "gateio" => Ok(Box::new(GateIo {})),
-        "kraken" => Ok(Box::new(Kraken {})),
-        "bitfinex" => Ok(Box::new(Bitfinex {})),
-        "deribit" => Ok(Box::new(Deribit {})),
-        "test" => Ok(Box::new(TestFeed {})),
-        _ => Err(InternalError(format!("unknown price feed {}", feed_id))),
+        FeedId::Bitstamp => Box::new(Bitstamp {}),
+        FeedId::GateIO => Box::new(GateIo {}),
+        FeedId::Kraken => Box::new(Kraken {}),
+        FeedId::Bitfinex => Box::new(Bitfinex {}),
+        FeedId::Deribit => Box::new(Deribit {}),
     }
+}
+
+#[cfg(feature = "test-feed")]
+pub fn create_price_feed(feed_id: &FeedId) -> Box<dyn PriceFeed + Send + Sync> {
+    match feed_id {
+        FeedId::Test => Box::new(TestFeed {}),
+    }
+}
+
+pub fn create_price_feeds(feed_ids: &[FeedId]) -> Vec<Box<dyn PriceFeed + Send + Sync>> {
+    feed_ids.iter().map(|x| create_price_feed(x)).collect()
+}
+
+pub async fn get_prices(
+    price_feeds: &[Box<dyn PriceFeed + Send + Sync>],
+    timestamp: OffsetDateTime,
+    asset_pair: AssetPair,
+) -> Vec<f64> {
+    futures::stream::iter(price_feeds.iter())
+        .then(|pricefeed| async {
+            pricefeed
+                .retrieve_price(asset_pair, timestamp)
+                .await
+                .map_err(|err| {
+                    error!("cannot retrieve price {}", err);
+                    err
+                })
+                .ok()
+        })
+        .collect::<Vec<Option<f64>>>()
+        .await
+        .into_iter()
+        .flatten()
+        .collect::<Vec<f64>>()
+}
+
+pub fn aggregate_price(
+    prices: &Vec<f64>,
+    aggregation_type: AggregationType,
+    asset_pair: AssetPair,
+) -> Option<f64> {
+    if prices.is_empty() {
+        None
+    } else {
+        match aggregation_type {
+            AggregationType::Average => {
+                let avg_price = prices.iter().sum::<f64>() / prices.len() as f64;
+                let avg_price = avg_price.round();
+                info!("average price of {} is {}", asset_pair, avg_price);
+                Some(avg_price)
+            }
+            AggregationType::Median => {
+                let mut sorted_prices = prices.to_vec();
+                sorted_prices.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                if sorted_prices.len() % 2 == 0 {
+                    let i = sorted_prices.len() / 2 - 1;
+                    let j = sorted_prices.len() / 2;
+                    let median_price = (sorted_prices[i] + sorted_prices[j]) / 2.0;
+                    info!(
+                        "median price of {} is {} (avg of {} and {})",
+                        asset_pair, median_price, sorted_prices[i], sorted_prices[j]
+                    );
+                    Some(median_price)
+                } else {
+                    let median_price = sorted_prices[sorted_prices.len() / 2];
+                    info!("median price of {} is {}", asset_pair, median_price);
+                    Some(median_price)
+                }
+            }
+        }
+    }
+}
+
+/// Returns the aggregated price obtained from the given price feeds, or `None` of none of the
+/// feeds could be queried.
+pub async fn get_aggregate_price_from_feeds(
+    price_feeds: &[Box<dyn PriceFeed + Send + Sync>],
+    timestamp: OffsetDateTime,
+    asset_pair: AssetPair,
+    aggregation_type: AggregationType,
+) -> Option<f64> {
+    let prices = get_prices(price_feeds, timestamp, asset_pair).await;
+    aggregate_price(&prices, aggregation_type, asset_pair)
 }
 
 mod bitfinex;
@@ -42,3 +154,92 @@ mod deribit;
 mod gateio;
 mod kraken;
 mod test_feed;
+
+#[cfg(test)]
+mod tests {
+    use crate::{oracle::pricefeeds::aggregate_price, AggregationType, AssetPair};
+
+    #[test]
+    fn test_aggregate() {
+        assert_eq!(
+            None,
+            aggregate_price(&vec![], AggregationType::Average, AssetPair::BTCUSD)
+        );
+        assert_eq!(
+            None,
+            aggregate_price(&vec![], AggregationType::Median, AssetPair::BTCUSD)
+        );
+        assert_eq!(
+            Some(10.0),
+            aggregate_price(&vec![10.0], AggregationType::Average, AssetPair::BTCUSD)
+        );
+        assert_eq!(
+            Some(10.0),
+            aggregate_price(&vec![10.0], AggregationType::Median, AssetPair::BTCUSD)
+        );
+        assert_eq!(
+            Some(15.0),
+            aggregate_price(
+                &vec![10.0, 20.0],
+                AggregationType::Average,
+                AssetPair::BTCUSD
+            )
+        );
+        assert_eq!(
+            Some(15.0),
+            aggregate_price(
+                &vec![10.0, 20.0],
+                AggregationType::Median,
+                AssetPair::BTCUSD
+            )
+        );
+        assert_eq!(
+            Some(20.0),
+            aggregate_price(
+                &vec![10.0, 20.0, 30.0],
+                AggregationType::Average,
+                AssetPair::BTCUSD
+            )
+        );
+        assert_eq!(
+            Some(20.0),
+            aggregate_price(
+                &vec![10.0, 30.0, 20.0],
+                AggregationType::Median,
+                AssetPair::BTCUSD
+            )
+        );
+        assert_eq!(
+            Some(35.0),
+            aggregate_price(
+                &vec![20.0, 30.0, 40.0, 50.0],
+                AggregationType::Average,
+                AssetPair::BTCUSD
+            )
+        );
+        assert_eq!(
+            Some(35.0),
+            aggregate_price(
+                &vec![40.0, 50.0, 20.0, 30.0],
+                AggregationType::Median,
+                AssetPair::BTCUSD
+            )
+        );
+        assert_eq!(
+            Some(30.0),
+            aggregate_price(
+                &vec![10.0, 20.0, 30.0, 40.0, 50.0],
+                AggregationType::Average,
+                AssetPair::BTCUSD
+            )
+        );
+        assert_eq!(
+            Some(40.0),
+            aggregate_price(
+                &vec![20.0, 40.0, 50.0, 30.0, 60.0],
+                AggregationType::Median,
+                AssetPair::BTCUSD
+            )
+        );
+    }
+}

--- a/src/oracle/pricefeeds/test_feed.rs
+++ b/src/oracle/pricefeeds/test_feed.rs
@@ -58,7 +58,6 @@ mod tests {
     use std::fs::File;
 
     use super::*;
-    use actix_web::dev::ResourcePath;
     use std::io::Write;
 
     #[tokio::test]


### PR DESCRIPTION
This PR refactors the code to:
* provide better type safety by using an enum for the feed ids instead of strings
* make available some price feed related utility functions to be used externally