### PR TITLE
Prevent bitstamp price feed from panicking

### DIFF
--- a/src/oracle/pricefeeds/bitstamp.rs
+++ b/src/oracle/pricefeeds/bitstamp.rs
@@ -71,7 +71,15 @@ impl PriceFeed for Bitstamp {
             )));
         }
 
-        let price = res.data.unwrap().ohlc[0].open.parse().unwrap();
+        let price = res
+            .data
+            .unwrap()
+            .ohlc
+            .get(0)
+            .ok_or(PriceFeedError::PriceNotAvailableError(asset_pair, instant))?
+            .open
+            .parse()
+            .unwrap();
         info!("bitstamp price {price}");
         Ok(price)
     }


### PR DESCRIPTION
I encountered the following error:
```
lava-lender  | thread 'actix-server worker 0' panicked at /usr/local/cargo/git/checkouts/sibyls-6cee6472640b63e2
/c67976e/src/oracle/pricefeeds/bitstamp.rs:74:43:
lava-lender  | index out of bounds: the len is 0 but the index is 0
```

It seems the api can somehow return an empty array for the `ohlc` field, not sure why but this will at least prevent a panic from occuring.