### PR TITLE
test: added coverage to inspect_key

### DIFF
--- a/sibyls-keygen/src/main.rs
+++ b/sibyls-keygen/src/main.rs
@@ -145,6 +145,27 @@ mod tests {
     }
 
     #[test]
+    fn test_inspect_key_from_path() {
+        use secp256k1::rand::Rng;
+        let secp = Secp256k1::new();
+        let random_filename: String = rand::thread_rng()
+            .sample_iter(&rand::distributions::Alphanumeric)
+            .take(10)
+            .map(char::from)
+            .collect();
+        let path = env::current_dir().unwrap().join(random_filename);
+
+        let (_, expected_public_key_hex) = generate_keypair(&secp, Some(&path), false).unwrap();
+        
+        let path_string = path.to_str().unwrap();
+        let public_key_hex = inspect_key(&secp, path_string).unwrap();
+        assert_eq!(public_key_hex.len(), 66);
+        assert_eq!(public_key_hex, expected_public_key_hex);
+
+        fs::remove_file(&path).expect("Unable to delete test file");
+    }
+
+    #[test]
     fn test_generate_keypair_file() {
         use secp256k1::rand::Rng;
         let secp = Secp256k1::new();

--- a/sibyls-keygen/src/main.rs
+++ b/sibyls-keygen/src/main.rs
@@ -132,6 +132,16 @@ mod tests {
 
         assert_eq!(public_key_hex.len(), 66);
         assert_eq!(public_key_hex, expected_public_key_hex);
+
+        // Test that if a non hex secret key is used we error
+        let secret_key_non_hex = "G1b8c027c89bb2c8b8db0b93721e1e9885e92b6b68d44c1f9026f83e5a2763df";
+        let error_response = inspect_key(&secp, secret_key_non_hex);
+        match error_response {
+            Err(ref e) => {
+                assert_eq!("Invalid secret key", format!("{}", e));
+            }
+            Ok(_) => panic!("Expected an error, but got Ok"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Was learning a bit about the oracle implementation and figured I add some test coverage to learn more about how things work!

Added test coverage to `sibyls-keygen` for the `inspect_key` function

- 442278086aaf44b4941197d3eff2bfd7877cfdbc Added test for when a non-hex key is passed and asserted that we get an error `Invalid secret key`
- fca55f62df8e8e841b74f6925e2ff84638cd44b1 Added test for when a path is used in `inspect_key` and then asserted that when we used that path the `pubic_key_hex` is equal to what we generated using `generate_keypair`

Additional coverage can be added for when we use a key in an env file