### PR TITLE
refactor: use event_maturity_epoc directly from OracleAnnouncment

### DIFF
--- a/sibyls/src/db/dual.rs
+++ b/sibyls/src/db/dual.rs
@@ -389,8 +389,9 @@ mod tests {
         let maturation = maturation.checked_add(Duration::days(3)).unwrap();
         let (ann, sk_nonces) =
             build_test_announcement(&maturation, &keypar, &secp, SigningVersion::Basic);
+        let event_maturity_epoch = OffsetDateTime::from_unix_timestamp(ann.oracle_event.event_maturity_epoch.into()).expect("invalid timestamp");
 
-        let event = sled.store_announcement(&maturation, AssetPair::BTCUSD, &ann, &sk_nonces);
+        let event = sled.store_announcement(&event_maturity_epoch, AssetPair::BTCUSD, &ann, &sk_nonces);
         assert!(event.is_ok());
 
         let res = dual.list_oracle_events(Filters {

--- a/sibyls/src/db/postgres.rs
+++ b/sibyls/src/db/postgres.rs
@@ -405,7 +405,9 @@ mod tests {
 
         let (ann, sk_nonces) =
             build_test_announcement(&maturation, &keypar, &secp, SigningVersion::Basic);
-        let res = db.store_announcement(&maturation, ASSET_PAIR, &ann, &sk_nonces);
+        let event_maturity_epoch = OffsetDateTime::from_unix_timestamp(ann.oracle_event.event_maturity_epoch.into()).expect("invalid     timestamp");
+
+        let res = db.store_announcement(&event_maturity_epoch, ASSET_PAIR, &ann, &sk_nonces);
         assert!(res.is_ok());
 
         let res = db.list_oracle_events(Filters {

--- a/sibyls/src/db/sled.rs
+++ b/sibyls/src/db/sled.rs
@@ -392,7 +392,9 @@ mod tests {
 
         let (ann, sk_nonces) =
             build_test_announcement(&maturation, &keypar, &secp, SigningVersion::Basic);
-        let res = db.store_announcement(&maturation, ASSET_PAIR, &ann, &sk_nonces);
+        let event_maturity_epoch = OffsetDateTime::from_unix_timestamp(ann.oracle_event.event_maturity_epoch.into()).expect("invalid     timestamp");
+
+        let res = db.store_announcement(&event_maturity_epoch, ASSET_PAIR, &ann, &sk_nonces);
         assert!(res.is_ok());
 
         let res = db.list_oracle_events(Filters {

--- a/sibyls/src/oracle/oracle_scheduler/mod.rs
+++ b/sibyls/src/oracle/oracle_scheduler/mod.rs
@@ -369,14 +369,18 @@ fn create_event(
         signing_version,
     )?;
 
+    let event_maturity_epoch =
+        OffsetDateTime::from_unix_timestamp(announcement.oracle_event.event_maturity_epoch.into())
+            .expect("invalid timestamp");
+
     info!(
         "creating oracle event (announcement only) with maturation {} and announcement {:#?}",
-        maturation, announcement
+        event_maturity_epoch, announcement
     );
 
     let asset_pair = oracle.asset_pair_info.asset_pair;
     if let Err(err) = oracle.event_database.store_announcement(
-        &maturation,
+        &event_maturity_epoch,
         asset_pair,
         &announcement,
         &outstanding_sk_nonces,
@@ -384,7 +388,7 @@ fn create_event(
         error!("Cannot store announcement: {err}");
     } else {
         let event_value = EventData {
-            maturation,
+            maturation: event_maturity_epoch,
             asset_pair,
             outstanding_sk_nonces: Some(outstanding_sk_nonces),
         };


### PR DESCRIPTION
## Description
Right now when we are storing the `maturation` it is coming from `siblys` directly when it would make more sense to keep it in line with what is being generated directly from the `OracleAnnouncement` from `rustdlc` to avoid any differences between the `announcement` hex and what we store in the db for the `maturation` date

In this change we are now using the `event_maturity_epoc` and converting the `i32` into a `OffsetDateTime`

This shouldn't change any functionality and is just refactor

## Note
This is a minor change so let me know and I'm happy to close

I just figured it makes more sense to use the maturity directly from the announcement because the `event_maturity_epoch` is serialized into the `announcement` hex